### PR TITLE
Restore missing dependency tty-which

### DIFF
--- a/inf7.gemspec
+++ b/inf7.gemspec
@@ -43,5 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "optimist", "~> 3.0.1"
   spec.add_dependency "nokogiri", "~> 1.11.7"
   spec.add_dependency "tty-table", "~> 0.12.0"
+  spec.add_dependency "tty-which", "~> 0.4.0"
 
 end


### PR DESCRIPTION
This was removed in commit c95bb24 (updating docs, gemspec, 2021-06-05); however, it is still required by lib/inf7.rb and lib/inf7/doc.rb. Without this, building and installing the gem per INSTALL.md went smoothly, but attempting to run e.g. 'inf7 --version' produced a runtime error.